### PR TITLE
Add wget to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ ARG base_image
 
 FROM ${base_image}
 
+RUN apt-get -y upgrade
+RUN apt-get install -y wget
+  
 RUN wget -q -L -O /usr/local/bin/jq "https://github.com/jqlang/jq/releases/latest/download/jq-linux-amd64" && \
   chmod +x /usr/local/bin/jq && \
   mkdir -p /opt/resource/logs/    

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG base_image
 
 FROM ${base_image}
 
-RUN apt-get update && RUN apt-get install -y wget
+RUN apt-get update && apt-get install -y wget
   
 RUN wget -q -L -O /usr/local/bin/jq "https://github.com/jqlang/jq/releases/latest/download/jq-linux-amd64" && \
   chmod +x /usr/local/bin/jq && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ ARG base_image
 
 FROM ${base_image}
 
-RUN apt-get -y upgrade
-RUN apt-get install -y wget
+RUN apt-get update && RUN apt-get install -y wget
   
 RUN wget -q -L -O /usr/local/bin/jq "https://github.com/jqlang/jq/releases/latest/download/jq-linux-amd64" && \
   chmod +x /usr/local/bin/jq && \


### PR DESCRIPTION
## Changes proposed in this pull request:
- `0.052 /bin/sh: 1: wget: not found`, taking that as a hint that `wget` is not in the hardened image
-


## Security Considerations
None